### PR TITLE
Explicitely import the __BYTE_ORDER macros if not already available

### DIFF
--- a/lib/proto_common.h
+++ b/lib/proto_common.h
@@ -36,12 +36,16 @@
 
 #include "libprotoident.h"
 
+#ifndef __BYTE_ORDER
+#include <endian.h>
+#endif
+
 #define ANY -1
 
 #define MASKOCTET(x) \
         ((x) == ANY ? 0U : 255U)
 
-#if BYTE_ORDER == BIG_ENDIAN
+#if __BYTE_ORDER == __BIG_ENDIAN
 #define FORMUP(a,b,c,d) \
         (unsigned)((((a)&0xFF)<<24)|(((b)&0xFF)<<16)|(((c)&0xFF)<<8)|((d)&0xFF))
 #else


### PR DESCRIPTION
On my system, Fedora23 the BYTE_ORDER macro has not be taken into account.
Adding the explicit import it works as expected
