### PR TITLE
fix compiler warnings

### DIFF
--- a/lib/libprotoident.cc
+++ b/lib/libprotoident.cc
@@ -413,6 +413,8 @@ const char *lpi_print_category(lpi_category_t category) {
 			return "Location";
 		case LPI_CATEGORY_CACHING:
 			return "Caching";
+		case LPI_CATEGORY_MOBILE_APP:
+			return "Mobile App";
 		case LPI_CATEGORY_ICMP:
 			return "ICMP";
 		case LPI_CATEGORY_MIXED:
@@ -425,6 +427,8 @@ const char *lpi_print_category(lpi_category_t category) {
 			return "Unsupported";
 		case LPI_CATEGORY_NO_CATEGORY:
 			return "Uncategorised";
+		case LPI_CATEGORY_LAST:
+			return "Last";
 	}
 
 	return "Invalid_Category";


### PR DESCRIPTION
```
libprotoident.cc:345:9: warning: enumeration values 'LPI_CATEGORY_MOBILE_APP' and 'LPI_CATEGORY_LAST' not handled in switch [-Wswitch]
        switch(category) {
               ^
```
