### PR TITLE
fixed memory leak in lpi_init_library() function

### DIFF
--- a/lib/libprotoident.cc
+++ b/lib/libprotoident.cc
@@ -100,6 +100,26 @@ void lpi_free_library() {
 	free_protocols(&TCP_protocols);
 	free_protocols(&UDP_protocols);
 
+   if (lpi_icmp != NULL) {
+      delete lpi_icmp;
+      lpi_icmp = NULL;
+   }
+
+   if (lpi_unsupported != NULL) {
+      delete lpi_unsupported;
+      lpi_unsupported = NULL;
+   }
+
+   if (lpi_unknown_tcp != NULL) {
+      delete lpi_unknown_tcp;
+      lpi_unknown_tcp = NULL;
+   }
+
+   if (lpi_unknown_udp != NULL) {
+      delete lpi_unknown_udp;
+      lpi_unknown_udp = NULL;
+   }
+
 	init_called = false;
 }
 


### PR DESCRIPTION
Hello,
this is possible fix of memory leak in `lpi_init_library()` function.

Allocated [memory](https://github.com/wanduow/libprotoident/blob/master/lib/proto_manager.cc#L544) in `init_other_protocols(...)` function is not freed by `lpi_free_library()`.