### PR TITLE
Distinguish no payload and no first packet

### DIFF
--- a/lib/libprotoident.h
+++ b/lib/libprotoident.h
@@ -605,6 +605,7 @@ typedef enum {
 
         LPI_PROTO_INVALID,     /* No single valid protocol */
 	LPI_PROTO_NO_PAYLOAD,
+	LPI_PROTO_NO_FIRSTPKT,
 	LPI_PROTO_UNSUPPORTED,
         LPI_PROTO_UNKNOWN,
 	LPI_PROTO_LAST		/** ALWAYS have this as the last value */

--- a/lib/proto_manager.cc
+++ b/lib/proto_manager.cc
@@ -204,6 +204,7 @@ int register_tcp_protocols(LPIModuleMap *mod_map) {
 	register_norton_backup(mod_map);
 	register_notes_rpc(mod_map);
 	register_tcp_no_payload(mod_map);
+	register_tcp_no_firstpkt(mod_map);
 	register_omegle(mod_map);
 	register_openvpn(mod_map);
 	register_ourworld(mod_map);

--- a/lib/tcp/Makefile.am
+++ b/lib/tcp/Makefile.am
@@ -135,6 +135,7 @@ libprotoident_tcp_la_SOURCES = \
 	lpi_nntp.cc \
 	lpi_nntps.cc \
 	lpi_nopayload.cc \
+	lpi_nofirstpkt.cc \
 	lpi_norton_backup.cc \
 	lpi_notes_rpc.cc \
 	lpi_omegle.cc \

--- a/lib/tcp/lpi_nofirstpkt.cc
+++ b/lib/tcp/lpi_nofirstpkt.cc
@@ -1,0 +1,52 @@
+/*
+ *
+ * Copyright (c) 2011-2016 The University of Waikato, Hamilton, New Zealand.
+ * All rights reserved.
+ *
+ * This file is part of libprotoident.
+ *
+ * This code has been developed by the University of Waikato WAND
+ * research group. For further information please see http://www.wand.net.nz/
+ *
+ * libprotoident is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libprotoident is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+#include <string.h>
+
+#include "libprotoident.h"
+#include "proto_manager.h"
+#include "proto_common.h"
+
+bool match_no_firstpkt(lpi_data_t *data, lpi_module_t *mod UNUSED) {
+
+    if ( (data->observed[0] != 0 || data->observed[1] != 0) &&
+        (data->payload_len[0] == 0 && data->payload_len[1] == 0) )
+            return true;
+
+	return false;
+}
+
+static lpi_module_t lpi_no_firstpkt = {
+	LPI_PROTO_NO_FIRSTPKT,
+	LPI_CATEGORY_NOPAYLOAD,
+	"No_FirstPkt",
+	0,	/* Must supercede all other protocols */
+	match_no_firstpkt
+};
+
+void register_tcp_no_firstpkt(LPIModuleMap *mod_map) {
+	register_protocol(&lpi_no_firstpkt, mod_map);
+}

--- a/lib/tcp/lpi_nopayload.cc
+++ b/lib/tcp/lpi_nopayload.cc
@@ -35,9 +35,6 @@ bool match_no_payload(lpi_data_t *data, lpi_module_t *mod UNUSED) {
 	if (data->observed[0] == 0 && data->observed[1] == 0)
 		return true;
 
-        if (data->payload_len[0] == 0 && data->payload_len[1] == 0)
-                return true;
-
 	return false;
 }
 

--- a/lib/tcp/tcp_protocols.h
+++ b/lib/tcp/tcp_protocols.h
@@ -165,6 +165,7 @@ void register_nntps(LPIModuleMap *mod_map);
 void register_norton_backup(LPIModuleMap *mod_map);
 void register_notes_rpc(LPIModuleMap *mod_map);
 void register_tcp_no_payload(LPIModuleMap *mod_map);
+void register_tcp_no_firstpkt(LPIModuleMap *mod_map);
 void register_omegle(LPIModuleMap *mod_map);
 void register_openvpn(LPIModuleMap *mod_map);
 void register_ourworld(LPIModuleMap *mod_map);


### PR DESCRIPTION
Hi,
We had very large flows classified as "No_Payload" because we couldn't observe the first few packets. The name "No_Payload" is very confusing in this case. I made a another class "No_FirstPkt" that takes care of this.